### PR TITLE
Open class roster in new tab

### DIFF
--- a/CourseGrab/templates/index.html
+++ b/CourseGrab/templates/index.html
@@ -35,7 +35,7 @@
         
         <p id="disclaimer">
             Don't know the ID of your course? <br>Find it on the
-            <a href='https://classes.cornell.edu'>class roster.</a>
+            <a href='https://classes.cornell.edu' rel="noopener noreferrer" target="_blank">class roster.</a>
         </p>
     </div>
 </div>


### PR DESCRIPTION
Especially for when you want to add multiple class id's, you would always want the class roster to open in a new tab for reference. It is rather awkward to have to go back and forward multiple times just to add class id's.